### PR TITLE
test existence of .xcworkspace

### DIFF
--- a/src/rctapp.js
+++ b/src/rctapp.js
@@ -56,7 +56,7 @@ program
 
   // Build Xcode Project
   let buildCMD = ['-scheme', `${appName}`, '-configuration', 'Debug', '-destination', `platform=${platform},name=${device}`, 'build', '-derivedDataPath', cwdPath('build')];
-  if (fs.statSync(cwdPath(`${appName}.xcworkspace`)).isDirectory()) {
+  if (fs.existsSync(cwdPath(`${appName}.xcworkspace`)) && fs.statSync(cwdPath(`${appName}.xcworkspace`)).isDirectory()) {
     buildCMD.push('-workspace', `${appName}.xcworkspace`);
   } else {
     buildCMD.push('-project', `${appName}.xcodeproj`);


### PR DESCRIPTION
looks like statSync throws if the file/dir doesn't exist, this should fix it.